### PR TITLE
Fix: videojs.getComponent is not a function / videojs is not defined

### DIFF
--- a/src/components/SourceMenuButton.js
+++ b/src/components/SourceMenuButton.js
@@ -1,3 +1,4 @@
+import videojs from 'video.js';
 import SourceMenuItem from './SourceMenuItem';
 
 const MenuButton = videojs.getComponent('MenuButton');

--- a/src/components/SourceMenuItem.js
+++ b/src/components/SourceMenuItem.js
@@ -1,3 +1,4 @@
+import videojs from 'video.js';
 const MenuItem = videojs.getComponent('MenuItem');
 
 class SourceMenuItem extends MenuItem


### PR DESCRIPTION
Fixes `videojs.getComponent is not a function` / `videojs is not defined`.

Imports video.js into each component, which eliminates the following error (and similar variations) when using video-http-source-selector with webpack:

```
videojs-http-source-selector.es.js:36 Uncaught TypeError: videojs.getComponent is not a function
    at Module.<anonymous> (videojs-http-source-selector.es.js:36)
    at Module../node_modules/videojs-http-source-selector/dist/videojs-http-source-selector.es.js (videojs-http-source-selector.es.js:264)
```

This change also resolves compiled output in dist/ mixing up use of `videojs` and `videojs$1`.

Fixes #1 and succeeds #3.

(Only src/ included as I assume you'd prefer to rebuild dist/ yourself, but can add that to the PR if you prefer.)