### PR TITLE
Fix SourceMenuItem not being selectable

### DIFF
--- a/src/components/SourceMenuButton.js
+++ b/src/components/SourceMenuButton.js
@@ -27,7 +27,7 @@ class SourceMenuButton extends MenuButton
     }
 
     // Bind update to qualityLevels changes
-    //this.player().qualityLevels.on(['change', 'addqualitylevel'], videojs.bind( this, this.update) );
+    this.player().qualityLevels().on(['change', 'addqualitylevel'], videojs.bind(this, this.update));
   };
 
   createEl() {

--- a/src/components/SourceMenuItem.js
+++ b/src/components/SourceMenuItem.js
@@ -4,8 +4,8 @@ const MenuItem = videojs.getComponent('MenuItem');
 class SourceMenuItem extends MenuItem
 {
   constructor(player, options) {
-    super(player, options);
     options.selectable = true;
+    super(player, options);
   }
 
   handleClick() {

--- a/src/components/SourceMenuItem.js
+++ b/src/components/SourceMenuItem.js
@@ -1,19 +1,20 @@
 import videojs from 'video.js';
 const MenuItem = videojs.getComponent('MenuItem');
+const Component = videojs.getComponent('Component');
 
 class SourceMenuItem extends MenuItem
 {
   constructor(player, options) {
     options.selectable = true;
+    options.multiSelectable = false;
+
     super(player, options);
   }
 
   handleClick() {
     var selected = this.options_;
     console.log("Changing quality to:", selected.label);
-
-    this.selected_ = true;
-    this.selected(true);
+    super.handleClick();
 
     var levels = this.player().qualityLevels();
     for(var i = 0; i < levels.length; i++) {
@@ -29,11 +30,10 @@ class SourceMenuItem extends MenuItem
   }
 
   update() {
-    var levels = this.player().qualityLevels();
-    var selection = levels.selectedIndex;
-    this.selected(this.options_.index == selection);
-    this.selected_ = (this.options_.index === selection);
+    var selectedIndex = this.player().qualityLevels().selectedIndex;
+    this.selected(this.options_.index == selectedIndex);
   }
 }
 
+Component.registerComponent('SourceMenuItem', SourceMenuItem);
 export default SourceMenuItem;


### PR DESCRIPTION
The menu item was not selectable as the super-constructur of
SourceMenuItem (i.e. MenuItem) was called before the 'selectable'
property on the 'options' object was set.

Fixes https://github.com/jfujita/videojs-http-source-selector/issues/7.